### PR TITLE
Added a feature to display the time strings either in 24-hour or am/p…

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -92,6 +92,7 @@ class _MyHomePageState extends State<MyHomePage> {
         child: TimePlanner(
           startHour: 6,
           endHour: 23,
+          use24HourFormat: false,
           style: TimePlannerStyle(
             // cellHeight: 60,
             // cellWidth: 60,

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,35 +21,28 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -80,28 +73,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -113,7 +106,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -134,21 +127,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
+    version: "0.4.12"
   time_planner:
     dependency: "direct dev"
     description:
@@ -156,20 +149,13 @@ packages:
       relative: true
     source: path
     version: "0.1.1"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
   flutter: ">=1.17.0"

--- a/lib/src/config/global_config.dart
+++ b/lib/src/config/global_config.dart
@@ -8,6 +8,7 @@ int? cellHeight;
 int? cellWidth;
 double? horizontalTaskPadding;
 late double totalHours;
+late bool use24HourFormat;
 late int totalDays;
 late int startHour;
 BorderRadiusGeometry? borderRadius;

--- a/lib/src/time_planner.dart
+++ b/lib/src/time_planner.dart
@@ -28,6 +28,7 @@ class TimePlanner extends StatefulWidget {
   /// When widget loaded scroll to current time with an animation. Default is true
   final bool? currentTimeAnimation;
 
+  /// Whether time is displayed in 24 hour format or am/pm format in the time column on the left.
   final bool use24HourFormat;
 
   /// Time planner widget
@@ -191,6 +192,7 @@ class _TimePlannerState extends State<TimePlanner> {
                                     horizontal: !config.use24HourFormat ? 4 : 0,
                                   ),
                                   child: TimePlannerTime(
+                                    // this returns the formatted time string based on the use24HourFormat argument.
                                     time: formattedTime(i),
                                   ),
                                 )

--- a/lib/src/time_planner.dart
+++ b/lib/src/time_planner.dart
@@ -127,6 +127,8 @@ class _TimePlannerState extends State<TimePlanner> {
 
   @override
   Widget build(BuildContext context) {
+    // we need to update the tasks list in case the tasks have changed
+    tasks = widget.tasks ?? [];
     mainHorizontalController.addListener(() {
       dayHorizontalController.jumpTo(mainHorizontalController.offset);
     });

--- a/lib/src/time_planner.dart
+++ b/lib/src/time_planner.dart
@@ -28,6 +28,8 @@ class TimePlanner extends StatefulWidget {
   /// When widget loaded scroll to current time with an animation. Default is true
   final bool? currentTimeAnimation;
 
+  final bool use24HourFormat;
+
   /// Time planner widget
   const TimePlanner({
     Key? key,
@@ -36,6 +38,7 @@ class TimePlanner extends StatefulWidget {
     required this.headers,
     this.tasks,
     this.style,
+    this.use24HourFormat = false,
     this.currentTimeAnimation,
   }) : super(key: key);
   @override
@@ -86,6 +89,7 @@ class _TimePlannerState extends State<TimePlanner> {
     config.totalHours = (widget.endHour - widget.startHour).toDouble();
     config.totalDays = widget.headers.length;
     config.startHour = widget.startHour;
+    config.use24HourFormat = widget.use24HourFormat;
     config.borderRadius = style.borderRadius;
     isAnimated = widget.currentTimeAnimation;
     tasks = widget.tasks ?? [];
@@ -179,9 +183,15 @@ class _TimePlannerState extends State<TimePlanner> {
                               for (int i = widget.startHour;
                                   i <= widget.endHour;
                                   i++)
-                                TimePlannerTime(
-                                  time: i.toString() + ':00',
-                                ),
+                                Padding(
+                                  // we need some additional padding horizontally if we're showing in am/pm format
+                                  padding: EdgeInsets.symmetric(
+                                    horizontal: !config.use24HourFormat ? 4 : 0,
+                                  ),
+                                  child: TimePlannerTime(
+                                    time: formattedTime(i),
+                                  ),
+                                )
                             ],
                           ),
                           Container(
@@ -357,5 +367,20 @@ class _TimePlannerState extends State<TimePlanner> {
         ),
       ),
     );
+  }
+
+  String formattedTime(int hour) {
+    /// this method formats the input hour into a time string
+    /// modifing it as necessary based on the use24HourFormat flag .
+    if (config.use24HourFormat) {
+      // we use the hour as-is
+      return hour.toString() + ':00';
+    } else {
+      // we format the time to use the am/pm scheme
+      if (hour == 0) return "12:00 am";
+      if (hour < 12) return "$hour:00 am";
+      if (hour == 12) return "12:00 pm";
+      return "${hour - 12}:00 pm";
+    }
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,35 +21,28 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -80,28 +73,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -113,7 +106,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -134,35 +127,28 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.12"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
   flutter: ">=1.17.0"


### PR DESCRIPTION
#9 ... I added a feature to show time in either 24-hour or am/pm format (on the time column of the TimePlanner widget). Note that this formatting of the time strings has nothing to do with the internal logic of how the package handles time. The time strings are formatted just before being displayed to the user. In all parts of the package, 'hour' is still an integer from 0 to 23. Time strings are formatted by default in am/pm format. To use the 24 hour format, pass the 'use24HourFormat' argument in the TimePlanner constructor.