### PR TITLE
Optional set the time in the top of the time block 

### DIFF
--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>9.0</string>
+  <string>11.0</string>
 </dict>
 </plist>

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -171,6 +171,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -185,6 +186,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -272,7 +274,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -349,7 +351,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -398,7 +400,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -45,5 +45,7 @@
 	<false/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 </dict>
 </plist>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -93,7 +93,7 @@ class _MyHomePageState extends State<MyHomePage> {
           startHour: 6,
           endHour: 23,
           use24HourFormat: false,
-          isTimeOnAxis: false,
+          setTimeOnAxis: false,
           style: TimePlannerStyle(
             // cellHeight: 60,
             // cellWidth: 60,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -93,6 +93,7 @@ class _MyHomePageState extends State<MyHomePage> {
           startHour: 6,
           endHour: 23,
           use24HourFormat: false,
+          isTimeOnAxis: true,
           style: TimePlannerStyle(
             // cellHeight: 60,
             // cellWidth: 60,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -93,7 +93,7 @@ class _MyHomePageState extends State<MyHomePage> {
           startHour: 6,
           endHour: 23,
           use24HourFormat: false,
-          isTimeOnAxis: true,
+          isTimeOnAxis: false,
           style: TimePlannerStyle(
             // cellHeight: 60,
             // cellWidth: 60,

--- a/lib/src/config/global_config.dart
+++ b/lib/src/config/global_config.dart
@@ -11,4 +11,5 @@ late double totalHours;
 late bool use24HourFormat;
 late int totalDays;
 late int startHour;
+late bool isTimeOnAxis;
 BorderRadiusGeometry? borderRadius;

--- a/lib/src/config/global_config.dart
+++ b/lib/src/config/global_config.dart
@@ -11,5 +11,5 @@ late double totalHours;
 late bool use24HourFormat;
 late int totalDays;
 late int startHour;
-late bool isTimeOnAxis;
+late bool setTimeOnAxis;
 BorderRadiusGeometry? borderRadius;

--- a/lib/src/time_planner.dart
+++ b/lib/src/time_planner.dart
@@ -31,7 +31,7 @@ class TimePlanner extends StatefulWidget {
   final bool use24HourFormat;
 
   //Whether the time is displayed on the axis of the tim or on the center of the timeblock. Default is false.
-  final bool isTimeOnAxis;
+  final bool setTimeOnAxis;
 
   /// Time planner widget
   const TimePlanner({
@@ -42,7 +42,7 @@ class TimePlanner extends StatefulWidget {
     this.tasks,
     this.style,
     this.use24HourFormat = false,
-    this.isTimeOnAxis = false,
+    this.setTimeOnAxis = false,
     this.currentTimeAnimation,
   }) : super(key: key);
   @override
@@ -96,7 +96,7 @@ class _TimePlannerState extends State<TimePlanner> {
     config.totalDays = widget.headers.length;
     config.startHour = widget.startHour;
     config.use24HourFormat = widget.use24HourFormat;
-    config.isTimeOnAxis = widget.isTimeOnAxis;
+    config.setTimeOnAxis = widget.setTimeOnAxis;
     config.borderRadius = style.borderRadius;
     isAnimated = widget.currentTimeAnimation;
     tasks = widget.tasks ?? [];
@@ -200,7 +200,7 @@ class _TimePlannerState extends State<TimePlanner> {
                                   child: TimePlannerTime(
                                     // this returns the formatted time string based on the use24HourFormat argument.
                                     time: formattedTime(i),
-                                    isTimeOnAxis: config.isTimeOnAxis,
+                                    setTimeOnAxis: config.setTimeOnAxis,
                                   ),
                                 )
                             ],

--- a/lib/src/time_planner.dart
+++ b/lib/src/time_planner.dart
@@ -30,6 +30,9 @@ class TimePlanner extends StatefulWidget {
   /// Whether time is displayed in 24 hour format or am/pm format in the time column on the left.
   final bool use24HourFormat;
 
+  //Whether the time is displayed on the axis of the tim or on the center of the timeblock. Default is false.
+  final bool isTimeOnAxis;
+
   /// Time planner widget
   const TimePlanner({
     Key? key,
@@ -39,6 +42,7 @@ class TimePlanner extends StatefulWidget {
     this.tasks,
     this.style,
     this.use24HourFormat = false,
+    this.isTimeOnAxis = false,
     this.currentTimeAnimation,
   }) : super(key: key);
   @override
@@ -92,6 +96,7 @@ class _TimePlannerState extends State<TimePlanner> {
     config.totalDays = widget.headers.length;
     config.startHour = widget.startHour;
     config.use24HourFormat = widget.use24HourFormat;
+    config.isTimeOnAxis = widget.isTimeOnAxis;
     config.borderRadius = style.borderRadius;
     isAnimated = widget.currentTimeAnimation;
     tasks = widget.tasks ?? [];
@@ -195,6 +200,7 @@ class _TimePlannerState extends State<TimePlanner> {
                                   child: TimePlannerTime(
                                     // this returns the formatted time string based on the use24HourFormat argument.
                                     time: formattedTime(i),
+                                    isTimeOnAxis: config.isTimeOnAxis,
                                   ),
                                 )
                             ],

--- a/lib/src/time_planner_time.dart
+++ b/lib/src/time_planner_time.dart
@@ -5,13 +5,13 @@ import 'package:time_planner/src/config/global_config.dart' as config;
 class TimePlannerTime extends StatelessWidget {
   /// Text it will be show as hour
   final String? time;
-  final bool? isTimeOnAxis;
+  final bool? setTimeOnAxis;
 
   /// Show the hour for each row of time planner
   const TimePlannerTime({
     Key? key,
     this.time,
-    this.isTimeOnAxis,
+    this.setTimeOnAxis,
   }) : super(key: key);
 
   @override
@@ -21,7 +21,7 @@ class TimePlannerTime extends StatelessWidget {
       width: 60,
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 0.0, vertical: 0.0),
-        child: isTimeOnAxis! ? Text(time!) : Center(child: Text(time!)),
+        child: setTimeOnAxis! ? Text(time!) : Center(child: Text(time!)),
       ),
     );
   }

--- a/lib/src/time_planner_time.dart
+++ b/lib/src/time_planner_time.dart
@@ -5,11 +5,13 @@ import 'package:time_planner/src/config/global_config.dart' as config;
 class TimePlannerTime extends StatelessWidget {
   /// Text it will be show as hour
   final String? time;
+  final bool? isTimeOnAxis;
 
   /// Show the hour for each row of time planner
   const TimePlannerTime({
     Key? key,
     this.time,
+    this.isTimeOnAxis,
   }) : super(key: key);
 
   @override
@@ -19,7 +21,7 @@ class TimePlannerTime extends StatelessWidget {
       width: 60,
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 0.0, vertical: 0.0),
-        child: Center(child: Text(time!)),
+        child: !isTimeOnAxis! ? Center(child: Text(time!)) : Text(time!),
       ),
     );
   }

--- a/lib/src/time_planner_time.dart
+++ b/lib/src/time_planner_time.dart
@@ -21,7 +21,7 @@ class TimePlannerTime extends StatelessWidget {
       width: 60,
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 0.0, vertical: 0.0),
-        child: !isTimeOnAxis! ? Center(child: Text(time!)) : Text(time!),
+        child: isTimeOnAxis! ? Text(time!) : Center(child: Text(time!)),
       ),
     );
   }


### PR DESCRIPTION
 I added a feature to show the time either in the middle of the time block like it is now or at the top of the time block where also the axis begins. To use the top formatting of the time notation, pass the 'setTimeOnAxis' argument in the TimePlanner constructor.